### PR TITLE
Improve guidance when repos missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ $CROSS_REPO_BASE/
 
 ### Cross-Repo Commands
 
+Before running any `wt-multi-*` command, make sure every repo you reference has already been cloned or initialized into `$WORKTREE_BASE` (e.g., with `wt-clone <git-url>` or `wt-init <name>`). The multi commands reuse those existing bare repos and will now guide you to set them up if they are missing.
+
 | Command | Description |
 |---------|-------------|
 | `wt-multi-new <branch> <repos...>` | Create worktrees in multiple repos with symlinks |

--- a/worktree.sh
+++ b/worktree.sh
@@ -170,6 +170,23 @@ _wt_list_repos() {
     done
 }
 
+# Ensure a repo exists under WORKTREE_BASE before running commands that rely on it
+_wt_require_repo() {
+    local repo="$1"
+    local context="$2"
+    local repo_path="$WORKTREE_BASE/$repo"
+
+    if [[ ! -d "$repo_path/.bare" ]]; then
+        echo "Error: Repository '$repo' is not initialized at $repo_path"
+        echo "To fix this, clone it first: wt-clone <git-url> $repo"
+        echo "Or create a new local repo: wt-init $repo"
+        if [[ -n "$context" ]]; then
+            echo "Retry $context after the repo is available."
+        fi
+        return 1
+    fi
+}
+
 # Create a new feature worktree
 # Usage: wt-new <repo> <branch-name>
 wt-new() {
@@ -183,15 +200,15 @@ wt-new() {
     fi
 
     local repo_path="$WORKTREE_BASE/$repo"
+
+    if ! _wt_require_repo "$repo" "wt-new"; then
+        return 1
+    fi
+
     local default_branch
     default_branch=$(_wt_default_branch "$repo")
     local branch_dir
     branch_dir=$(_wt_branch_to_dir "$branch")
-
-    if [[ ! -d "$repo_path/.bare" ]]; then
-        echo "Error: Repository '$repo' not found at $repo_path"
-        return 1
-    fi
 
     cd "$repo_path" || return 1
 
@@ -220,13 +237,13 @@ wt-continue() {
     fi
 
     local repo_path="$WORKTREE_BASE/$repo"
-    local branch_dir
-    branch_dir=$(_wt_branch_to_dir "$branch")
 
-    if [[ ! -d "$repo_path/.bare" ]]; then
-        echo "Error: Repository '$repo' not found at $repo_path"
+    if ! _wt_require_repo "$repo" "wt-continue"; then
         return 1
     fi
+
+    local branch_dir
+    branch_dir=$(_wt_branch_to_dir "$branch")
 
     local default_branch
     default_branch=$(_wt_default_branch "$repo")
@@ -455,6 +472,19 @@ wt-multi-new() {
     local task_dir="$CROSS_REPO_BASE/$branch_dir"
     mkdir -p "$task_dir"
 
+    local missing_repos=()
+    for repo in "${repos[@]}"; do
+        if ! _wt_require_repo "$repo" "wt-multi-new"; then
+            missing_repos+=("$repo")
+        fi
+    done
+
+    if [[ ${#missing_repos[@]} -gt 0 ]]; then
+        echo ""
+        echo "wt-multi-new aborted. Clone the repos above before retrying."
+        return 1
+    fi
+
     for repo in "${repos[@]}"; do
         echo "Creating worktree for $repo..."
 
@@ -500,6 +530,19 @@ wt-multi-add() {
     if [[ ! -d "$task_dir" ]]; then
         echo "Task '$branch' not found at $task_dir"
         echo "Use wt-multi-new to create a new task"
+        return 1
+    fi
+
+    local missing_repos=()
+    for repo in "${repos[@]}"; do
+        if ! _wt_require_repo "$repo" "wt-multi-add"; then
+            missing_repos+=("$repo")
+        fi
+    done
+
+    if [[ ${#missing_repos[@]} -gt 0 ]]; then
+        echo ""
+        echo "wt-multi-add aborted. Clone the repos above before retrying."
         return 1
     fi
 


### PR DESCRIPTION
## Summary
- add `_wt_require_repo` helper so all commands emit consistent instructions when a repo hasn't been cloned into `$WORKTREE_BASE`
- have `wt-new`, `wt-continue`, `wt-multi-new`, and `wt-multi-add` call the helper up front to catch missing repos before doing work
- document the prerequisite in the README so users learn about the requirement before running any `wt-multi-*` command

## Testing
- `wt-multi-new shared-feature repo-one repo-two` (missing repos) in a temp WORKTREE_BASE
- `wt-multi-new shared-feature repo-one repo-two` after cloning both repos from a local bare remote
