### PR TITLE
Add mirror-based repo setup for CI/CD pods and remote agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Shell utilities for managing git worktrees using the **bare repo + worktree patt
 - Create/remove worktrees with simple commands
 - Tab completion for repos, branches, and tasks
 - Cross-repo task management with symlinks
+- Mirror-based setup for CI/CD pods and remote agents (via git alternates)
 - Configurable default branches per repo
 - Works with any set of repositories
 
@@ -186,6 +187,7 @@ Before running any `wt-multi-*` command, make sure every repo you reference has 
 
 | Command | Description |
 |---------|-------------|
+| `wt-mirror-setup [repos...]` | Bootstrap repos from mirrors in parallel (requires `WORKTREE_MIRROR_BASE`) |
 | `wt-multi-new <branch> <repos...>` | Create worktrees in multiple repos with symlinks |
 | `wt-multi-add <branch> <repos...>` | Add repos to an existing cross-repo task |
 | `wt-multi-rm <branch>` | Archive a cross-repo task (removes worktrees, archives remaining files) |
@@ -295,6 +297,7 @@ wt-init my-new-project develop  # optional custom default branch
 | `WORKTREE_BASE` | Yes | Directory containing bare repos |
 | `CROSS_REPO_BASE` | Yes | Directory for cross-repo task symlinks |
 | `CROSS_REPO_ARCHIVE` | Yes | Directory where archived tasks are moved by `wt-multi-rm` |
+| `WORKTREE_MIRROR_BASE` | No | Directory containing pre-populated bare repo mirrors (for fast setup) |
 | `WT_DEFAULT_BRANCH_OVERRIDES` | No | Associative array of repo→branch overrides (usually not needed) |
 
 ### Default Branch Detection
@@ -309,6 +312,67 @@ declare -A WT_DEFAULT_BRANCH_OVERRIDES=(
     [old-service]=develop
 )
 export WT_DEFAULT_BRANCH_OVERRIDES
+```
+
+### Mirror-Based Setup (CI/CD Pods, Remote Agents)
+
+When `WORKTREE_MIRROR_BASE` is set, repos can be bootstrapped from pre-populated bare repo mirrors instead of cloning over the network. This is designed for environments like CI/CD pods or remote coding agent sessions where a read-only volume of git mirrors is mounted.
+
+**How it works:**
+- Mirrors are linked via git alternates (`git clone --bare --shared`) — objects are read directly from the mirror, not copied
+- New objects (commits, trees) are written locally; the mirror is never modified
+- A `git fetch origin` syncs remote tracking refs (fast since objects are read via alternates)
+- All existing `wt-*` and `wt-multi-*` commands auto-detect mirrors — if a repo doesn't exist yet and a mirror is available, it's set up transparently
+
+**Mirror directory layout:**
+
+```
+$WORKTREE_MIRROR_BASE/
+├── repo-a.git/          # bare repo (git clone --mirror)
+├── repo-b/              # bare repo (without .git suffix)
+└── repo-c/
+    └── .bare/           # wt-utils layout
+```
+
+**Usage:**
+
+```bash
+export WORKTREE_MIRROR_BASE="/repos"  # read-only mount
+
+# Bulk setup — discovers and sets up all mirrors in parallel
+wt-mirror-setup
+
+# Or setup specific repos
+wt-mirror-setup repo-a repo-b
+
+# Clone by name (uses mirror, keeps mirror's origin)
+wt-clone repo-a
+
+# Clone by name with explicit origin override
+wt-clone repo-a git@github.com:org/repo-a.git
+
+# Regular URL clone is accelerated when a mirror matches the name
+wt-clone git@github.com:org/repo-a.git
+
+# wt-new and wt-multi-new auto-init from mirror if repo missing
+wt-multi-new auth-fix repo-a repo-b repo-c
+```
+
+**Pod init script example:**
+
+```bash
+#!/bin/bash
+export WORKTREE_BASE="/workspace/worktrees"
+export CROSS_REPO_BASE="/workspace/cross-repo-tasks"
+export CROSS_REPO_ARCHIVE="/workspace/cross-repo-tasks/wt-archive"
+export WORKTREE_MIRROR_BASE="/repos"  # read-only volume mount
+source /path/to/worktree.sh
+
+# Set up all repos from mirrors (parallel, fast)
+wt-mirror-setup
+
+# Ready to work
+wt-multi-new my-feature backend frontend api
 ```
 
 ## Notes

--- a/completions.bash
+++ b/completions.bash
@@ -171,6 +171,23 @@ _wt_multi_add_complete() {
     esac
 }
 
+# List available mirrors from WORKTREE_MIRROR_BASE
+_wt_list_mirrors() {
+    [[ -n "${WORKTREE_MIRROR_BASE:-}" && -d "$WORKTREE_MIRROR_BASE" ]] || return
+    local entry
+    for entry in "$WORKTREE_MIRROR_BASE"/*; do
+        [[ -d "$entry" ]] || continue
+        basename "$entry" .git
+    done | sort -u
+}
+
+# Completion for wt-mirror-setup: mirror names
+_wt_mirror_complete() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "$(_wt_list_mirrors)" -- "$cur"))
+}
+
 # Register completions
 complete -F _wt_cd_complete wt-cd
 complete -F _wt_new_complete wt-new
@@ -182,3 +199,4 @@ complete -F _wt_multi_complete wt-multi-new
 complete -F _wt_multi_add_complete wt-multi-add
 complete -F _wt_task_complete wt-multi-cd
 complete -F _wt_task_complete wt-multi-rm
+complete -F _wt_mirror_complete wt-mirror-setup

--- a/completions.fish
+++ b/completions.fish
@@ -98,3 +98,17 @@ complete -c wt-multi-rm -n "test (count (commandline -opc)) -eq 1" -a "(__wt_tas
 
 # wt-multi-ls: no args
 complete -c wt-multi-ls -f
+
+# Helper: list available mirrors
+function __wt_mirrors
+    if set -q WORKTREE_MIRROR_BASE; and test -d "$WORKTREE_MIRROR_BASE"
+        for entry in $WORKTREE_MIRROR_BASE/*
+            test -d "$entry"; or continue
+            basename "$entry" .git
+        end | sort -u
+    end
+end
+
+# wt-mirror-setup: mirror names
+complete -c wt-mirror-setup -f
+complete -c wt-mirror-setup -a "(__wt_mirrors)"

--- a/completions.ps1
+++ b/completions.ps1
@@ -206,3 +206,24 @@ Register-ArgumentCompleter -CommandName 'Set-WorktreeTaskLocation', 'wt-multi-cd
 # Remove-WorktreeTask / wt-multi-rm: task only
 # ===========================
 Register-ArgumentCompleter -CommandName 'Remove-WorktreeTask', 'wt-multi-rm' -ParameterName 'Branch' -ScriptBlock (New-TaskCompleter)
+
+# ===========================
+# Initialize-WorktreeMirrors / wt-mirror-setup: mirror names
+# ===========================
+Register-ArgumentCompleter -CommandName 'Initialize-WorktreeMirrors', 'wt-mirror-setup' -ParameterName 'Repos' -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    $null = $commandName, $parameterName, $commandAst, $fakeBoundParameters
+    
+    if ($env:WORKTREE_MIRROR_BASE -and (Test-Path $env:WORKTREE_MIRROR_BASE)) {
+        $seen = @{}
+        Get-ChildItem $env:WORKTREE_MIRROR_BASE -Directory | ForEach-Object {
+            $n = $_.Name -replace '\.git$', ''
+            if (-not $seen.ContainsKey($n)) {
+                $seen[$n] = $true
+                $n
+            }
+        } | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+    }
+}

--- a/completions.zsh
+++ b/completions.zsh
@@ -108,6 +108,24 @@ _wt-multi-add() {
     esac
 }
 
+# List available mirrors
+_wt_mirrors() {
+    if [[ -n "${WORKTREE_MIRROR_BASE:-}" && -d "$WORKTREE_MIRROR_BASE" ]]; then
+        local mirrors=()
+        local entry
+        for entry in "$WORKTREE_MIRROR_BASE"/*; do
+            [[ -d "$entry" ]] || continue
+            mirrors+=($(basename "$entry" .git))
+        done
+        _describe 'mirror' mirrors
+    fi
+}
+
+# Completion for wt-mirror-setup
+_wt-mirror-setup() {
+    _wt_mirrors
+}
+
 # Register completions
 compdef _wt-cd wt-cd
 compdef _wt-new wt-new
@@ -119,3 +137,4 @@ compdef _wt-multi-new wt-multi-new
 compdef _wt-multi-add wt-multi-add
 compdef _wt_tasks wt-multi-cd
 compdef _wt_tasks wt-multi-rm
+compdef _wt-mirror-setup wt-mirror-setup

--- a/setup.ps1
+++ b/setup.ps1
@@ -146,6 +146,13 @@ else {
         default { $CrossRepoArchive = Join-Path $CrossRepoBase 'wt-archive' }
     }
     
+    # Ask about mirror base
+    Write-Host ''
+    Write-Host 'Mirror base directory (for pre-populated bare repo mirrors, e.g., in CI/CD pods).'
+    Write-Host 'Leave blank if not using mirrors.'
+    $WorktreeMirrorBase = Read-Host 'Mirror base directory []'
+    $WorktreeMirrorBase = $WorktreeMirrorBase -replace '^~', $HOME
+
     # Ask about default branch overrides
     Write-Host ''
     Write-Host "Some repos may use a non-standard default branch (e.g., 'master' instead of 'main')."
@@ -205,6 +212,9 @@ $configLines += "# Installed: $(Get-Date -Format 'o')"
 $configLines += "`$env:WORKTREE_BASE = `"$WorktreeBase`""
 $configLines += "`$env:CROSS_REPO_BASE = `"$CrossRepoBase`""
 $configLines += "`$env:CROSS_REPO_ARCHIVE = `"$CrossRepoArchive`""
+if ($WorktreeMirrorBase) {
+    $configLines += "`$env:WORKTREE_MIRROR_BASE = `"$WorktreeMirrorBase`""
+}
 
 # Add overrides if any
 if ($Overrides.Count -gt 0) {

--- a/setup.sh
+++ b/setup.sh
@@ -169,6 +169,13 @@ else
             ;;
     esac
 
+    # Ask about mirror base (for pre-populated bare repos)
+    echo ""
+    echo "Mirror base directory (for pre-populated bare repo mirrors, e.g., in CI/CD pods)."
+    echo "Leave blank if not using mirrors."
+    read -r -p "Mirror base directory []: " WORKTREE_MIRROR_BASE
+    WORKTREE_MIRROR_BASE="${WORKTREE_MIRROR_BASE/#\~/$HOME}"
+
     # Ask about default branch overrides
     echo ""
     echo "Some repos may use a non-standard default branch (e.g., 'master' instead of 'main')."
@@ -227,6 +234,10 @@ set -gx WORKTREE_BASE \"$WORKTREE_BASE\"
 set -gx CROSS_REPO_BASE \"$CROSS_REPO_BASE\"
 set -gx CROSS_REPO_ARCHIVE \"$CROSS_REPO_ARCHIVE\"
 "
+    if [[ -n "$WORKTREE_MIRROR_BASE" ]]; then
+        CONFIG+="set -gx WORKTREE_MIRROR_BASE \"$WORKTREE_MIRROR_BASE\"
+"
+    fi
 
     # Add overrides if any (fish uses individual variables)
     if [[ -n "$OVERRIDES" ]]; then
@@ -253,6 +264,10 @@ export WORKTREE_BASE=\"$WORKTREE_BASE\"
 export CROSS_REPO_BASE=\"$CROSS_REPO_BASE\"
 export CROSS_REPO_ARCHIVE=\"$CROSS_REPO_ARCHIVE\"
 "
+    if [[ -n "$WORKTREE_MIRROR_BASE" ]]; then
+        CONFIG+="export WORKTREE_MIRROR_BASE=\"$WORKTREE_MIRROR_BASE\"
+"
+    fi
 
     # Add overrides if any
     if [[ -n "$OVERRIDES" ]]; then

--- a/worktree.fish
+++ b/worktree.fish
@@ -41,21 +41,60 @@ function _wt_default_branch
     echo "main"
 end
 
-# Clone a remote repo into the worktree structure
-function wt-clone
-    set -l url $argv[1]
-    set -l name $argv[2]
-
-    if test -z "$url"
-        echo "Usage: wt-clone <git-url> [local-name]"
-        echo "Example: wt-clone git@github.com:user/repo.git"
-        echo "Example: wt-clone git@github.com:user/repo.git my-repo"
+# Find a mirror for a repo name in WORKTREE_MIRROR_BASE
+# Checks common bare repo layouts; prints path on success
+function _wt_find_mirror
+    set -l name $argv[1]
+    if not set -q WORKTREE_MIRROR_BASE; or test -z "$WORKTREE_MIRROR_BASE"
         return 1
     end
 
-    # Extract repo name from URL if not provided
-    if test -z "$name"
-        set name (basename "$url" .git)
+    for candidate in "$WORKTREE_MIRROR_BASE/$name.git" "$WORKTREE_MIRROR_BASE/$name" "$WORKTREE_MIRROR_BASE/$name/.bare"
+        if test -d "$candidate/objects"
+            echo "$candidate"
+            return 0
+        end
+    end
+    return 1
+end
+
+# Clone a repo into the worktree structure
+# Usage: wt-clone <git-url> [local-name]
+#        wt-clone <name> [origin-url]   (from mirror, requires WORKTREE_MIRROR_BASE)
+function wt-clone
+    set -l url ""
+    set -l name ""
+
+    # Detect whether the first arg is a URL or a plain repo name
+    if string match -q '*://*' -- $argv[1]; or string match -q '*@*:*' -- $argv[1]
+        set url $argv[1]
+        if test -n "$argv[2]"
+            set name $argv[2]
+        else
+            set name (basename "$url" .git)
+        end
+    else
+        set name $argv[1]
+        if test -n "$argv[2]"
+            set url $argv[2]
+        end
+    end
+
+    # Try to find a local mirror
+    set -l mirror_path ""
+    if test -n "$name"
+        set mirror_path (_wt_find_mirror "$name" 2>/dev/null); or set mirror_path ""
+    end
+
+    if test -z "$name"; or begin; test -z "$url"; and test -z "$mirror_path"; end
+        echo "Usage: wt-clone <git-url> [local-name]"
+        echo "       wt-clone <name> [origin-url]   (from mirror, requires WORKTREE_MIRROR_BASE)"
+        echo "Example: wt-clone git@github.com:user/repo.git"
+        echo "Example: wt-clone git@github.com:user/repo.git my-repo"
+        if set -q WORKTREE_MIRROR_BASE; and test -n "$WORKTREE_MIRROR_BASE"
+            echo "Example: wt-clone my-repo              (from mirror)"
+        end
+        return 1
     end
 
     set -l repo_path "$WORKTREE_BASE/$name"
@@ -65,21 +104,27 @@ function wt-clone
         return 1
     end
 
-    echo "Cloning $url into $repo_path..."
     mkdir -p "$repo_path"
     cd "$repo_path"
 
-    # Clone as bare repo
-    git clone --bare "$url" .bare
-
-    # Create .git pointer
-    echo "gitdir: ./.bare" > .git
-
-    # Configure fetch to get all branches
-    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-
-    # Fetch all branches
-    git fetch origin
+    if test -n "$mirror_path"
+        echo "Cloning $name from mirror ($mirror_path)..."
+        # --shared sets up alternates to read objects from the mirror (no copy)
+        git clone --bare --shared "$mirror_path" .bare
+        echo "gitdir: ./.bare" > .git
+        git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+        if test -n "$url"
+            git remote set-url origin "$url" 2>/dev/null; or git remote add origin "$url"
+        end
+        # Fetch to sync remote tracking refs (fast — objects read via alternates)
+        git fetch origin
+    else
+        echo "Cloning $url into $repo_path..."
+        git clone --bare "$url" .bare
+        echo "gitdir: ./.bare" > .git
+        git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+        git fetch origin
+    end
 
     # Detect default branch
     set -l default_branch (git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
@@ -98,6 +143,78 @@ function wt-clone
     echo "✓ Cloned $name (default branch: $default_branch)"
     echo "  Repo path: $repo_path"
     echo "  Worktree:  $repo_path/$default_branch"
+end
+
+# Bootstrap repos from mirrors in parallel
+# Usage: wt-mirror-setup [repo1] [repo2] ...
+#        wt-mirror-setup               (discover all mirrors)
+function wt-mirror-setup
+    if not set -q WORKTREE_MIRROR_BASE; or test -z "$WORKTREE_MIRROR_BASE"
+        echo "Error: WORKTREE_MIRROR_BASE must be set"
+        return 1
+    end
+
+    if not test -d "$WORKTREE_MIRROR_BASE"
+        echo "Error: WORKTREE_MIRROR_BASE ($WORKTREE_MIRROR_BASE) does not exist"
+        return 1
+    end
+
+    set -l repos $argv
+
+    # Auto-discover mirrors if none specified
+    if test (count $repos) -eq 0
+        set -l seen
+        for entry in $WORKTREE_MIRROR_BASE/*
+            test -d "$entry"; or continue
+            set -l n (basename "$entry" .git)
+            if not contains "$n" $seen; and _wt_find_mirror "$n" >/dev/null 2>&1
+                set -a seen "$n"
+                set -a repos "$n"
+            end
+        end
+    end
+
+    if test (count $repos) -eq 0
+        echo "No mirrors found in $WORKTREE_MIRROR_BASE"
+        return 1
+    end
+
+    echo "Setting up "(count $repos)" repo(s) from mirrors..."
+    echo ""
+
+    set -l tmpdir (mktemp -d)
+    set -l pids
+    set -l names
+
+    for name in $repos
+        if test -d "$WORKTREE_BASE/$name"
+            echo "  ⊘ $name (already exists, skipping)"
+            continue
+        end
+        begin; wt-clone "$name" > $tmpdir/$name.log 2>&1; end &
+        set -a pids $last_pid
+        set -a names "$name"
+    end
+
+    set -l failed 0
+    for i in (seq (count $pids))
+        if wait $pids[$i] 2>/dev/null
+            echo "  ✓ $names[$i]"
+        else
+            echo "  ✗ $names[$i]"
+            sed 's/^/    /' $tmpdir/$names[$i].log
+            set failed (math $failed + 1)
+        end
+    end
+
+    rm -rf $tmpdir
+    echo ""
+    if test $failed -eq 0
+        echo "✓ All repos set up from mirrors"
+    else
+        echo "⚠ $failed repo(s) failed"
+        return 1
+    end
 end
 
 # Initialize a new local repo in the worktree structure
@@ -171,14 +288,23 @@ function wt-new
     end
 
     set -l repo_path "$WORKTREE_BASE/$repo"
-    set -l default_branch (_wt_default_branch "$repo")
     set -l branch_dir (_wt_branch_to_dir "$branch")
-    set -l default_branch_dir (_wt_branch_to_dir "$default_branch")
+
+    # Auto-setup from mirror if repo doesn't exist yet
+    if not test -d "$repo_path/.bare"; and _wt_find_mirror "$repo" >/dev/null 2>&1
+        echo "Auto-initializing $repo from mirror..."
+        set -l _prev_dir (pwd)
+        wt-clone "$repo"; or return 1
+        cd "$_prev_dir"
+    end
 
     if not test -d "$repo_path/.bare"
         echo "Error: Repository '$repo' not found at $repo_path"
         return 1
     end
+
+    set -l default_branch (_wt_default_branch "$repo")
+    set -l default_branch_dir (_wt_branch_to_dir "$default_branch")
 
     cd "$repo_path"
 
@@ -205,14 +331,23 @@ function wt-continue
     end
 
     set -l repo_path "$WORKTREE_BASE/$repo"
-    set -l default_branch (_wt_default_branch "$repo")
     set -l branch_dir (_wt_branch_to_dir "$branch")
-    set -l default_branch_dir (_wt_branch_to_dir "$default_branch")
+
+    # Auto-setup from mirror if repo doesn't exist yet
+    if not test -d "$repo_path/.bare"; and _wt_find_mirror "$repo" >/dev/null 2>&1
+        echo "Auto-initializing $repo from mirror..."
+        set -l _prev_dir (pwd)
+        wt-clone "$repo"; or return 1
+        cd "$_prev_dir"
+    end
 
     if not test -d "$repo_path/.bare"
         echo "Error: Repository '$repo' not found at $repo_path"
         return 1
     end
+
+    set -l default_branch (_wt_default_branch "$repo")
+    set -l default_branch_dir (_wt_branch_to_dir "$default_branch")
 
     cd "$repo_path"
 
@@ -413,29 +548,70 @@ function wt-multi-new
     for repo in $repos
         echo "Creating worktree for $repo..."
 
-        # Create the worktree
-        if not begin
-            cd "$WORKTREE_BASE/$repo"
-            and wt-new "$repo" "$branch" >/dev/null 2>&1
-        end
+        # Create the worktree (save/restore cwd since wt-new changes directory)
+        set -l _prev_dir (pwd)
+        if not wt-new "$repo" "$branch" >/dev/null 2>&1
             # If it already exists, that's fine
             if test -d "$WORKTREE_BASE/$repo/$branch_dir"
                 echo "  Worktree already exists"
             else
                 echo "  Failed to create worktree for $repo"
+                cd "$_prev_dir"
                 continue
             end
         end
+        cd "$_prev_dir"
 
         # Create symlink in task directory
         ln -sf "$WORKTREE_BASE/$repo/$branch_dir" "$task_dir/$repo"
         echo "  ✓ $repo"
     end
 
+    # Create AGENTS.md and CLAUDE.md to help AI agents stay oriented
+    _wt_write_agent_files "$task_dir" "$branch" $repos
+
     echo ""
     echo "Task directory: $task_dir"
     ls -la "$task_dir"
     cd "$task_dir"
+end
+
+# Write AGENTS.md and CLAUDE.md files for a cross-repo task directory
+function _wt_write_agent_files
+    set -l task_dir $argv[1]
+    set -l branch $argv[2]
+    set -l repos $argv[3..-1]
+
+    # If no repos passed, gather from existing symlinks
+    if test (count $repos) -eq 0
+        set repos
+        for link in $task_dir/*
+            if test -L "$link"
+                set -a repos (basename "$link")
+            end
+        end
+    end
+
+    set -l repo_list ""
+    for repo in $repos
+        set repo_list "$repo_list- $repo
+"
+    end
+
+    set -l content "# Cross-Repo Task: $branch
+
+This is a cross-repo task directory. Each subdirectory is a symlinked repository worktree.
+
+**Important:** Always use this directory ($task_dir) as your workspace root.
+Do NOT navigate to or use the resolved symlink target paths under ~/worktree.
+Stay in this directory when running commands.
+
+## Repositories
+
+$repo_list"
+
+    echo "$content" > "$task_dir/AGENTS.md"
+    echo "$content" > "$task_dir/CLAUDE.md"
 end
 
 # Add repos to an existing cross-repo task
@@ -482,6 +658,9 @@ function wt-multi-add
         ln -sf "$WORKTREE_BASE/$repo/$branch_dir" "$task_dir/$repo"
         echo "  ✓ $repo"
     end
+
+    # Update AGENTS.md and CLAUDE.md with new repo list
+    _wt_write_agent_files "$task_dir" "$branch"
 
     echo ""
     echo "Task directory: $task_dir"

--- a/worktree.ps1
+++ b/worktree.ps1
@@ -108,6 +108,54 @@ function script:ConvertFrom-WorktreeDir {
     return $DirName -replace '__', '/'
 }
 
+function script:Find-WorktreeMirror {
+    param([string]$Name)
+    
+    if (-not $env:WORKTREE_MIRROR_BASE) { return $null }
+    
+    foreach ($candidate in @(
+        (Join-Path $env:WORKTREE_MIRROR_BASE "$Name.git"),
+        (Join-Path $env:WORKTREE_MIRROR_BASE $Name),
+        (Join-Path $env:WORKTREE_MIRROR_BASE $Name '.bare')
+    )) {
+        if (Test-Path (Join-Path $candidate 'objects') -PathType Container) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+function script:Confirm-WorktreeRepo {
+    param(
+        [string]$Repo,
+        [string]$Context
+    )
+    
+    $repoPath = Join-Path $env:WORKTREE_BASE $Repo
+    $barePath = Join-Path $repoPath '.bare'
+    
+    # Auto-setup from mirror if repo doesn't exist yet
+    if (-not (Test-Path $barePath -PathType Container)) {
+        $mirror = Find-WorktreeMirror $Repo
+        if ($mirror) {
+            Write-WtStatus "Auto-initializing $Repo from mirror..."
+            $prevLocation = Get-Location
+            try {
+                Copy-WorktreeFromRemote -Name $Repo
+            }
+            finally {
+                Set-Location $prevLocation
+            }
+        }
+    }
+    
+    if (-not (Test-Path $barePath -PathType Container)) {
+        Write-Error "Error: Repository '$Repo' is not initialized at $repoPath`nTo fix this, clone it first: wt-clone <git-url> $Repo`nOr create a new local repo: wt-init $Repo$(if ($Context) { "`nRetry $Context after the repo is available." })"
+        return $false
+    }
+    return $true
+}
+
 function script:Get-DefaultBranch {
     param([string]$Repo)
     
@@ -164,28 +212,47 @@ function Copy-WorktreeFromRemote {
     
     .DESCRIPTION
     Creates a bare repo clone with worktree support at WORKTREE_BASE.
+    When WORKTREE_MIRROR_BASE is set, mirrors are used automatically.
     
     .EXAMPLE
     Copy-WorktreeFromRemote -Url git@github.com:user/repo.git
     
     .EXAMPLE
     wt-clone git@github.com:user/repo.git my-custom-name
+    
+    .EXAMPLE
+    wt-clone my-repo  # from mirror
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Position = 0)]
         [string]$Url,
         
         [Parameter(Position = 1)]
         [string]$Name
     )
     
-    # Extract repo name from URL if not provided
-    if (-not $Name) {
-        # Normalize URL: remove trailing slashes and .git suffix
-        $normalizedUrl = $Url.TrimEnd('/') -replace '\.git$', ''
-        # Get last path segment as repo name
-        $Name = ($normalizedUrl -split '/')[-1]
+    # Detect whether first arg is a URL or a plain repo name
+    if ($Url -match '://|@.*:') {
+        # It's a URL
+        if (-not $Name) {
+            $normalizedUrl = $Url.TrimEnd('/') -replace '\.git$', ''
+            $Name = ($normalizedUrl -split '/')[-1]
+        }
+    }
+    else {
+        # First arg is a name, second (if any) is a URL override
+        $Name = $Url
+        $Url = if ($args.Count -gt 0) { $args[0] } else { '' }
+    }
+    
+    # Try to find a local mirror
+    $mirrorPath = if ($Name) { Find-WorktreeMirror $Name } else { $null }
+    
+    if (-not $Name -or (-not $Url -and -not $mirrorPath)) {
+        Write-WtStatus "Usage: wt-clone <git-url> [local-name]"
+        Write-WtStatus "       wt-clone <name> [origin-url]   (from mirror, requires WORKTREE_MIRROR_BASE)"
+        return
     }
     
     $repoPath = Join-Path $env:WORKTREE_BASE $Name
@@ -195,22 +262,32 @@ function Copy-WorktreeFromRemote {
         return
     }
     
-    Write-WtStatus "Cloning $Url into $repoPath..."
     New-Item -ItemType Directory -Path $repoPath -Force | Out-Null
     Push-Location $repoPath
     
     try {
-        # Clone as bare repo
-        git clone --bare $Url .bare
-        
-        # Create .git pointer
-        Set-Content -Path '.git' -Value 'gitdir: ./.bare'
-        
-        # Configure fetch to get all branches
-        git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
-        
-        # Fetch all branches
-        git fetch origin
+        if ($mirrorPath) {
+            Write-WtStatus "Cloning $Name from mirror ($mirrorPath)..."
+            # --shared sets up alternates to read objects from the mirror (no copy)
+            git clone --bare --shared $mirrorPath .bare
+            Set-Content -Path '.git' -Value 'gitdir: ./.bare'
+            git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+            if ($Url) {
+                $null = git remote set-url origin $Url 2>$null
+                if ($LASTEXITCODE -ne 0) {
+                    git remote add origin $Url
+                }
+            }
+            # Fetch to sync remote tracking refs (fast — objects read via alternates)
+            git fetch origin
+        }
+        else {
+            Write-WtStatus "Cloning $Url into $repoPath..."
+            git clone --bare $Url .bare
+            Set-Content -Path '.git' -Value 'gitdir: ./.bare'
+            git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+            git fetch origin
+        }
         
         # Detect default branch
         $defaultBranch = git symbolic-ref refs/remotes/origin/HEAD 2>$null
@@ -313,14 +390,12 @@ function New-Worktree {
     )
     
     $repoPath = Join-Path $env:WORKTREE_BASE $Repo
+    
+    if (-not (Confirm-WorktreeRepo $Repo 'wt-new')) { return }
+    
     $defaultBranch = Get-DefaultBranch $Repo
     $branchDir = ConvertTo-WorktreeDir $Branch
     $defaultBranchDir = ConvertTo-WorktreeDir $defaultBranch
-    
-    if (-not (Test-Path (Join-Path $repoPath '.bare') -PathType Container)) {
-        Write-Error "Error: Repository '$Repo' not found at $repoPath"
-        return
-    }
     
     $worktreePath = Join-Path $repoPath $branchDir
     if (-not $PSCmdlet.ShouldProcess($worktreePath, "Create worktree for branch '$Branch'")) {
@@ -365,14 +440,12 @@ function Resume-Worktree {
     )
     
     $repoPath = Join-Path $env:WORKTREE_BASE $Repo
+    
+    if (-not (Confirm-WorktreeRepo $Repo 'wt-continue')) { return }
+    
     $branchDir = ConvertTo-WorktreeDir $Branch
     $defaultBranch = Get-DefaultBranch $Repo
     $defaultBranchDir = ConvertTo-WorktreeDir $defaultBranch
-    
-    if (-not (Test-Path (Join-Path $repoPath '.bare') -PathType Container)) {
-        Write-Error "Error: Repository '$Repo' not found at $repoPath"
-        return
-    }
     
     Push-Location $repoPath
     
@@ -687,7 +760,7 @@ function New-WorktreeTask {
         
         $worktreePath = Join-Path $env:WORKTREE_BASE $repo $branchDir
         
-        Push-Location (Join-Path $env:WORKTREE_BASE $repo)
+        $prevLocation = Get-Location
         try {
             New-Worktree $repo $Branch 2>$null
         }
@@ -697,12 +770,11 @@ function New-WorktreeTask {
             }
             else {
                 Write-WtStatus "  Failed to create worktree for $repo" -Level Warning
+                Set-Location $prevLocation
                 continue
             }
         }
-        finally {
-            Pop-Location
-        }
+        Set-Location $prevLocation
         
         $linkPath = Join-Path $taskDir $repo
         if (-not (Test-Path $linkPath)) {
@@ -906,6 +978,89 @@ function Set-WorktreeTaskLocation {
     Set-Location (Join-Path $env:CROSS_REPO_BASE $branchDir)
 }
 
+function Initialize-WorktreeMirrors {
+    <#
+    .SYNOPSIS
+    Bootstraps repos from mirrors in WORKTREE_MIRROR_BASE.
+    
+    .DESCRIPTION
+    Discovers mirrors and sets up worktree repos from them.
+    If no repo names are given, all mirrors are discovered automatically.
+    
+    .EXAMPLE
+    Initialize-WorktreeMirrors
+    
+    .EXAMPLE
+    wt-mirror-setup cloud frontend api
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0, ValueFromRemainingArguments)]
+        [string[]]$Repos
+    )
+    
+    if (-not $env:WORKTREE_MIRROR_BASE) {
+        Write-Error 'WORKTREE_MIRROR_BASE must be set'
+        return
+    }
+    
+    if (-not (Test-Path $env:WORKTREE_MIRROR_BASE -PathType Container)) {
+        Write-Error "WORKTREE_MIRROR_BASE ($env:WORKTREE_MIRROR_BASE) does not exist"
+        return
+    }
+    
+    # Auto-discover mirrors if none specified
+    if (-not $Repos -or $Repos.Count -eq 0) {
+        $seen = @{}
+        $Repos = @()
+        Get-ChildItem $env:WORKTREE_MIRROR_BASE -Directory | ForEach-Object {
+            $n = $_.Name -replace '\.git$', ''
+            if (-not $seen.ContainsKey($n) -and (Find-WorktreeMirror $n)) {
+                $seen[$n] = $true
+                $Repos += $n
+            }
+        }
+    }
+    
+    if ($Repos.Count -eq 0) {
+        Write-WtStatus "No mirrors found in $env:WORKTREE_MIRROR_BASE"
+        return
+    }
+    
+    Write-WtStatus "Setting up $($Repos.Count) repo(s) from mirrors..."
+    Write-WtStatus ''
+    
+    $failed = 0
+    foreach ($name in $Repos) {
+        $repoPath = Join-Path $env:WORKTREE_BASE $name
+        if (Test-Path $repoPath) {
+            Write-WtStatus "  ⊘ $name (already exists, skipping)"
+            continue
+        }
+        
+        $prevLocation = Get-Location
+        try {
+            Copy-WorktreeFromRemote -Name $name *>$null
+            Write-WtStatus "  ✓ $name" -Level Success
+        }
+        catch {
+            Write-WtStatus "  ✗ $name" -Level Error
+            $failed++
+        }
+        finally {
+            Set-Location $prevLocation
+        }
+    }
+    
+    Write-WtStatus ''
+    if ($failed -eq 0) {
+        Write-WtStatus '✓ All repos set up from mirrors' -Level Success
+    }
+    else {
+        Write-WtStatus "⚠ $failed repo(s) failed" -Level Warning
+    }
+}
+
 # ===========================
 # Aliases for CLI compatibility
 # ===========================
@@ -925,6 +1080,7 @@ Set-Alias -Name wt-multi-add -Value Add-WorktreeTaskRepo
 Set-Alias -Name wt-multi-rm  -Value Remove-WorktreeTask
 Set-Alias -Name wt-multi-ls  -Value Get-WorktreeTask
 Set-Alias -Name wt-multi-cd  -Value Set-WorktreeTaskLocation
+Set-Alias -Name wt-mirror-setup -Value Initialize-WorktreeMirrors
 
 # Note: Functions and aliases are automatically available when dot-sourced.
 # No Export-ModuleMember needed (only works in .psm1 module files).

--- a/worktree.sh
+++ b/worktree.sh
@@ -31,7 +31,7 @@ _wt_default_branch() {
     local repo_path="$WORKTREE_BASE/$repo"
     
     # Check for manual override first
-    if [[ -n "${WT_DEFAULT_BRANCH_OVERRIDES[$repo]:-}" ]]; then
+    if declare -p WT_DEFAULT_BRANCH_OVERRIDES &>/dev/null && [[ -n "${WT_DEFAULT_BRANCH_OVERRIDES[$repo]:-}" ]]; then
         echo "${WT_DEFAULT_BRANCH_OVERRIDES[$repo]}"
         return
     fi
@@ -50,22 +50,60 @@ _wt_default_branch() {
     echo "main"
 }
 
-# Clone a remote repo into the worktree structure
-# Usage: wt-clone <git-url> [local-name]
-wt-clone() {
-    local url="$1"
-    local name="$2"
+# Find a mirror for a repo name in WORKTREE_MIRROR_BASE
+# Checks common bare repo layouts; prints path on success
+_wt_find_mirror() {
+    local name="$1"
+    [[ -n "${WORKTREE_MIRROR_BASE:-}" ]] || return 1
 
-    if [[ -z "$url" ]]; then
-        echo "Usage: wt-clone <git-url> [local-name]"
-        echo "Example: wt-clone git@github.com:user/repo.git"
-        echo "Example: wt-clone git@github.com:user/repo.git my-repo"
-        return 1
+    local candidate
+    for candidate in \
+        "$WORKTREE_MIRROR_BASE/$name.git" \
+        "$WORKTREE_MIRROR_BASE/$name" \
+        "$WORKTREE_MIRROR_BASE/$name/.bare"; do
+        if [[ -d "$candidate/objects" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Clone a repo into the worktree structure
+# Usage: wt-clone <git-url> [local-name]
+#        wt-clone <name> [origin-url]   (from mirror, requires WORKTREE_MIRROR_BASE)
+#
+# When WORKTREE_MIRROR_BASE is set, mirrors are used automatically:
+#   - Cloning by URL: if a mirror matches the repo name, it is copied locally
+#     instead of downloading over the network.
+#   - Cloning by name: the mirror is copied and its existing origin is kept
+#     (or overridden by the optional second argument).
+wt-clone() {
+    local url=""
+    local name=""
+
+    # Detect whether the first arg is a URL or a plain repo name
+    if [[ "$1" == *"://"* || "$1" == *"@"*":"* ]]; then
+        url="$1"
+        name="${2:-$(basename "$url" .git)}"
+    else
+        name="$1"
+        url="${2:-}"
     fi
 
-    # Extract repo name from URL if not provided
-    if [[ -z "$name" ]]; then
-        name=$(basename "$url" .git)
+    # Try to find a local mirror
+    local mirror_path=""
+    if [[ -n "$name" ]]; then
+        mirror_path=$(_wt_find_mirror "$name" 2>/dev/null) || true
+    fi
+
+    if [[ -z "$name" ]] || { [[ -z "$url" ]] && [[ -z "$mirror_path" ]]; }; then
+        echo "Usage: wt-clone <git-url> [local-name]"
+        echo "       wt-clone <name> [origin-url]   (from mirror, requires WORKTREE_MIRROR_BASE)"
+        echo "Example: wt-clone git@github.com:user/repo.git"
+        echo "Example: wt-clone git@github.com:user/repo.git my-repo"
+        [[ -n "${WORKTREE_MIRROR_BASE:-}" ]] && echo "Example: wt-clone my-repo              (from mirror)"
+        return 1
     fi
 
     local repo_path="$WORKTREE_BASE/$name"
@@ -75,27 +113,32 @@ wt-clone() {
         return 1
     fi
 
-    echo "Cloning $url into $repo_path..."
     mkdir -p "$repo_path"
     cd "$repo_path" || return 1
 
-    # Clone as bare repo
-    git clone --bare "$url" .bare
-
-    # Create .git pointer
-    echo "gitdir: ./.bare" > .git
-
-    # Configure fetch to get all branches
-    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-
-    # Fetch all branches
-    git fetch origin
+    if [[ -n "$mirror_path" ]]; then
+        echo "Cloning $name from mirror ($mirror_path)..."
+        # --shared sets up alternates to read objects from the mirror (no copy)
+        git clone --bare --shared "$mirror_path" .bare
+        echo "gitdir: ./.bare" > .git
+        git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+        if [[ -n "$url" ]]; then
+            git remote set-url origin "$url" 2>/dev/null || git remote add origin "$url"
+        fi
+        # Fetch to sync remote tracking refs (fast — objects read via alternates)
+        git fetch origin
+    else
+        echo "Cloning $url into $repo_path..."
+        git clone --bare "$url" .bare
+        echo "gitdir: ./.bare" > .git
+        git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+        git fetch origin
+    fi
 
     # Detect default branch
     local default_branch
     default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
     if [[ -z "$default_branch" ]]; then
-        # Try to detect from remote
         default_branch=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
     fi
     if [[ -z "$default_branch" ]]; then
@@ -110,6 +153,81 @@ wt-clone() {
     echo "✓ Cloned $name (default branch: $default_branch)"
     echo "  Repo path: $repo_path"
     echo "  Worktree:  $repo_path/$default_branch"
+}
+
+# Bootstrap repos from mirrors in parallel
+# Usage: wt-mirror-setup [repo1] [repo2] ...
+#        wt-mirror-setup               (discover all mirrors)
+wt-mirror-setup() {
+    if [[ -z "${WORKTREE_MIRROR_BASE:-}" ]]; then
+        echo "Error: WORKTREE_MIRROR_BASE must be set"
+        return 1
+    fi
+
+    if [[ ! -d "$WORKTREE_MIRROR_BASE" ]]; then
+        echo "Error: WORKTREE_MIRROR_BASE ($WORKTREE_MIRROR_BASE) does not exist"
+        return 1
+    fi
+
+    local repos=("$@")
+
+    # Auto-discover mirrors if none specified
+    if [[ ${#repos[@]} -eq 0 ]]; then
+        local entry seen=""
+        for entry in "$WORKTREE_MIRROR_BASE"/*; do
+            [[ -d "$entry" ]] || continue
+            local n
+            n=$(basename "$entry" .git)
+            # Deduplicate (e.g., repo and repo.git both exist)
+            if [[ " $seen " != *" $n "* ]] && _wt_find_mirror "$n" &>/dev/null; then
+                seen="$seen $n"
+                repos+=("$n")
+            fi
+        done
+    fi
+
+    if [[ ${#repos[@]} -eq 0 ]]; then
+        echo "No mirrors found in $WORKTREE_MIRROR_BASE"
+        return 1
+    fi
+
+    echo "Setting up ${#repos[@]} repo(s) from mirrors..."
+    echo ""
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local pids=()
+    local names=()
+
+    for name in "${repos[@]}"; do
+        if [[ -d "$WORKTREE_BASE/$name" ]]; then
+            echo "  ⊘ $name (already exists, skipping)"
+            continue
+        fi
+        ( wt-clone "$name" > "$tmpdir/$name.log" 2>&1 ) &
+        pids+=($!)
+        names+=("$name")
+    done
+
+    local failed=0
+    for i in "${!pids[@]}"; do
+        if wait "${pids[$i]}"; then
+            echo "  ✓ ${names[$i]}"
+        else
+            echo "  ✗ ${names[$i]}"
+            sed 's/^/    /' "$tmpdir/${names[$i]}.log"
+            ((failed++))
+        fi
+    done
+
+    rm -rf "$tmpdir"
+    echo ""
+    if [[ $failed -eq 0 ]]; then
+        echo "✓ All repos set up from mirrors"
+    else
+        echo "⚠ $failed repo(s) failed"
+        return 1
+    fi
 }
 
 # Initialize a new local repo in the worktree structure
@@ -175,6 +293,12 @@ _wt_require_repo() {
     local repo="$1"
     local context="$2"
     local repo_path="$WORKTREE_BASE/$repo"
+
+    # Auto-setup from mirror if repo doesn't exist yet
+    if [[ ! -d "$repo_path/.bare" ]] && _wt_find_mirror "$repo" &>/dev/null; then
+        echo "Auto-initializing $repo from mirror..."
+        ( wt-clone "$repo" ) || return 1
+    fi
 
     if [[ ! -d "$repo_path/.bare" ]]; then
         echo "Error: Repository '$repo' is not initialized at $repo_path"
@@ -488,8 +612,8 @@ wt-multi-new() {
     for repo in "${repos[@]}"; do
         echo "Creating worktree for $repo..."
 
-        # Create the worktree
-        (cd "$WORKTREE_BASE/$repo" && wt-new "$repo" "$branch" >/dev/null 2>&1) || {
+        # Create the worktree (subshell to isolate cd side-effects)
+        ( wt-new "$repo" "$branch" >/dev/null 2>&1 ) || {
             # If it already exists, that's fine
             if [[ -d "$WORKTREE_BASE/$repo/$branch_dir" ]]; then
                 echo "  Worktree already exists"
@@ -504,10 +628,52 @@ wt-multi-new() {
         echo "  ✓ $repo"
     done
 
+    # Create AGENTS.md and CLAUDE.md to help AI agents stay oriented
+    _wt_write_agent_files "$task_dir" "$branch" "${repos[@]}"
+
     echo ""
     echo "Task directory: $task_dir"
     ls -la "$task_dir"
     cd "$task_dir" || return 1
+}
+
+# Write AGENTS.md and CLAUDE.md files for a cross-repo task directory
+_wt_write_agent_files() {
+    local task_dir="$1"
+    local branch="$2"
+    shift 2
+    local repos=("$@")
+
+    # If no repos passed, gather from existing symlinks
+    if [[ ${#repos[@]} -eq 0 ]]; then
+        repos=()
+        for link in "$task_dir"/*; do
+            if [[ -L "$link" ]]; then
+                repos+=("$(basename "$link")")
+            fi
+        done
+    fi
+
+    local repo_list=""
+    for repo in "${repos[@]}"; do
+        repo_list="${repo_list}- ${repo}
+"
+    done
+
+    local content="# Cross-Repo Task: ${branch}
+
+This is a cross-repo task directory. Each subdirectory is a symlinked repository worktree.
+
+**Important:** Always use this directory (${task_dir}) as your workspace root.
+Do NOT navigate to or use the resolved symlink target paths under ~/worktree.
+Stay in this directory when running commands.
+
+## Repositories
+
+${repo_list}"
+
+    echo "$content" > "$task_dir/AGENTS.md"
+    echo "$content" > "$task_dir/CLAUDE.md"
 }
 
 # Add repos to an existing cross-repo task
@@ -569,6 +735,9 @@ wt-multi-add() {
         ln -sf "$WORKTREE_BASE/$repo/$branch_dir" "$task_dir/$repo"
         echo "  ✓ $repo"
     done
+
+    # Update AGENTS.md and CLAUDE.md with new repo list
+    _wt_write_agent_files "$task_dir" "$branch"
 
     echo ""
     echo "Task directory: $task_dir"


### PR DESCRIPTION
When WORKTREE_MIRROR_BASE is set, repos can be bootstrapped from pre-populated bare repo mirrors using git alternates (--shared). Objects are read directly from the mirror mount — no copying.

- Add _wt_find_mirror / Find-WorktreeMirror helper (bash/fish/ps1)
- wt-clone accepts plain name to clone from mirror (URL optional)
- wt-new / wt-continue auto-init from mirror if repo missing
- wt-multi-new / wt-multi-add inherit auto-init transparently
- Add wt-mirror-setup for bulk parallel bootstrap
- Add completions for wt-mirror-setup (all shells)
- Add WORKTREE_MIRROR_BASE to setup scripts
- Fix _wt_default_branch crash with hyphenated repo names in bash