### PR TITLE
fix: wt-new branches off origin instead of local default branch

### DIFF
--- a/worktree.fish
+++ b/worktree.fish
@@ -304,16 +304,15 @@ function wt-new
     end
 
     set -l default_branch (_wt_default_branch "$repo")
-    set -l default_branch_dir (_wt_branch_to_dir "$default_branch")
 
     cd "$repo_path"
 
-    # Update default branch first
-    git -C "$default_branch_dir" fetch origin
-    and git -C "$default_branch_dir" reset --hard origin/$default_branch
+    # Fetch latest and branch directly off origin — avoids touching the
+    # default-branch worktree (which may be detached or have local changes)
+    git fetch origin "$default_branch"
 
-    # Create worktree from default branch
-    git worktree add "$branch_dir" -b "$branch" $default_branch
+    # Create worktree from origin's default branch
+    git worktree add "$branch_dir" -b "$branch" "origin/$default_branch"
 
     cd "$branch_dir"
     echo "Created worktree: $repo_path/$branch_dir (branch: $branch)"

--- a/worktree.ps1
+++ b/worktree.ps1
@@ -395,7 +395,6 @@ function New-Worktree {
     
     $defaultBranch = Get-DefaultBranch $Repo
     $branchDir = ConvertTo-WorktreeDir $Branch
-    $defaultBranchDir = ConvertTo-WorktreeDir $defaultBranch
     
     $worktreePath = Join-Path $repoPath $branchDir
     if (-not $PSCmdlet.ShouldProcess($worktreePath, "Create worktree for branch '$Branch'")) {
@@ -405,10 +404,10 @@ function New-Worktree {
     Push-Location $repoPath
     
     try {
-        $defaultWorktree = Join-Path $repoPath $defaultBranchDir
-        git -C $defaultWorktree fetch origin
-        git -C $defaultWorktree reset --hard "origin/$defaultBranch"
-        git worktree add $branchDir -b $Branch $defaultBranch
+        # Fetch latest and branch directly off origin — avoids touching the
+        # default-branch worktree (which may be detached or have local changes)
+        git fetch origin $defaultBranch
+        git worktree add $branchDir -b $Branch "origin/$defaultBranch"
         
         Set-Location $branchDir
         Write-WtStatus "Created worktree: $repoPath\$branchDir (branch: $Branch)"

--- a/worktree.sh
+++ b/worktree.sh
@@ -336,13 +336,12 @@ wt-new() {
 
     cd "$repo_path" || return 1
 
-    # Update default branch first (worktree dir matches branch name)
-    local default_branch_dir
-    default_branch_dir=$(_wt_branch_to_dir "$default_branch")
-    git -C "$default_branch_dir" fetch origin && git -C "$default_branch_dir" reset --hard origin/"$default_branch"
+    # Fetch latest and branch directly off origin — avoids touching the
+    # default-branch worktree (which may be detached or have local changes)
+    git fetch origin "$default_branch"
 
-    # Create worktree from default branch
-    git worktree add "$branch_dir" -b "$branch" "$default_branch"
+    # Create worktree from origin's default branch
+    git worktree add "$branch_dir" -b "$branch" "origin/$default_branch"
 
     cd "$branch_dir" || return 1
     echo "Created worktree: $repo_path/$branch_dir (branch: $branch)"


### PR DESCRIPTION
## Problem

`wt-new` could silently create branches from a stale default branch.

The old code used `git reset --hard origin/<default>` inside the default branch's worktree to update the local ref before branching. If that worktree's HEAD was detached (common after rebase/checkout operations), the reset moved the detached HEAD but **never updated `refs/heads/<default>`**. The subsequent `git worktree add -b <new> <default>` would then branch from the stale local ref.

## Root cause

In git's worktree model, `git reset` updates the ref that HEAD points to. When HEAD is detached (not a symbolic ref), reset moves the detached HEAD directly — it doesn't touch `refs/heads/main`.

## Fix

Fetch and branch directly off `origin/<default-branch>` instead of going through the local ref. This:
- Is always correct after the fetch
- Never touches the default-branch worktree (no risk of destroying local changes or fighting detached state)
- Is simpler (fewer commands)

Applied to all three shell implementations: bash, fish, and PowerShell.